### PR TITLE
Revert "Bump actions/upload-artifact from v2.0.1 to 2.1.0"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -733,7 +733,7 @@ jobs:
             -p no:sugar \
             tests
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@2.1.0
+        uses: actions/upload-artifact@v2.0.1
         with:
           name: coverage-${{ matrix.python-version }}-group${{ matrix.group }}
           path: .coverage


### PR DESCRIPTION
Reverts bendews/home-assistant#2